### PR TITLE
Fix root domain parking -- needs to be "@" instead of empty. Add "www" subdomain.

### DIFF
--- a/install.json
+++ b/install.json
@@ -6,7 +6,12 @@
   "dns": [
     {
       "type": "A",
-      "name": "{{options.subdomain}}",
+      "name": "@",
+      "content": "165.227.80.250"
+    },
+    {
+      "type": "A",
+      "name": "www",
       "content": "165.227.80.250"
     },
     {
@@ -26,19 +31,12 @@
         "required": true,
         "services": ["domain-holder"]
       },
-      "subdomain": {
-        "title": "Subdomain",
-        "description": "The subdomain of your site you would like the parking page installed on. Should not already be used. Leave blank to host the parking page at the root of the site.",
-        "order": 20,
-        "type": "string",
-        "default": ""
-      },
       "price": {
         "title": "Price",
-        "description": "The price you are selling this site for in US Dollars",
+        "description": "The price you are selling this domain for in US Dollars",
         "type": "integer",
-        "order": 30,
-        "default": 5000
+        "order": 10,
+        "default": 1000
       }
     }
   }


### PR DESCRIPTION
Currently the instructions tell people to leave the subdomain field blank to park their domain, but this doesn't work anymore. It needs to be `@` to park the root domain. I am just removing the option to specify a subdomain, since it didn't make sense anyway. I also added a `www` A record and lowered the default price to $1000.
